### PR TITLE
fix logsetup module not found

### DIFF
--- a/flaat/caches.py
+++ b/flaat/caches.py
@@ -8,7 +8,7 @@ access to OIDC authenticated REST APIs.'''
 # pylint: disable=wrong-import-position, no-self-use, line-too-long
 
 import logging
-import logsetup
+from . import logsetup
 logger = logging.getLogger(__name__)
 
 class Issuer_config_cache():


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/dianagudu/motley_cue/pull/31#issuecomment-880627150

However, now I'm having the problem that nothing gets logged from flaat in motley_cue. How is the new logging supposed to be used in other modules?