### PR TITLE
Use .env for flask test config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ target/
 
 # DotEnv configuration
 .env
+.env.back
 
 # Database
 *.db

--- a/examples/example_flask.py
+++ b/examples/example_flask.py
@@ -71,7 +71,7 @@ class ProductionConfig(Config):
 
     # In production you might want to reduce the number of OP
     TRUSTED_OP_LIST = ["https://aai.egi.eu/oidc/"]
-    FLAAT_ISSUER = "https://aai.egi.eu/oidc/"
+    FLAAT_ISS = "https://aai.egi.eu/oidc/"
 
     # Define your request timeout for production
     FLAAT_REQUEST_TIMEOUT = 1.2
@@ -107,9 +107,9 @@ class TestingConfig(Config):
 # ------------------------------------------------------------------
 # Standard flask Application Factories snippet, source --------------
 # https://flask.palletsprojects.com/en/2.1.x/patterns/appfactories
-def create_app(config="ProductionConfig"):
+def create_app(config=f"{__name__}.ProductionConfig"):
     app = Flask(__name__)
-    app.config.from_object(f"{__name__}.{config}")
+    app.config.from_object(config)
 
     # Init application plugins
     flaat.init_app(app)

--- a/flaat/flask/__init__.py
+++ b/flaat/flask/__init__.py
@@ -21,7 +21,7 @@ class Flaat(BaseFlaat):
 
     def init_app(self, app):
         app.config.setdefault("TRUSTED_OP_LIST", [])
-        app.config.setdefault("FLAAT_ISSUER", "")
+        app.config.setdefault("FLAAT_ISS", "")
         app.config.setdefault("FLAAT_CLIENT_ID", "")
         app.config.setdefault("FLAAT_CLIENT_SECRET", "")
         app.config.setdefault("FLAAT_REQUEST_TIMEOUT", 1.2)  # seconds
@@ -52,14 +52,14 @@ class Flaat(BaseFlaat):
         """Returns the Flaat configured issuer URL.
         :return: Issuer URL of the pinned issuer
         """
-        return current_app.config["FLAAT_ISSUER"]
+        return current_app.config["FLAAT_ISS"]
 
     def set_issuer(self, issuer: str):
         """Pins the given issuer. Only users of this issuer will be able
         to use services.
         :param issuer: Issuer URL of the pinned issuer.
         """
-        current_app.config["FLAAT_ISSUER"] = issuer.rstrip("/")
+        current_app.config["FLAAT_ISS"] = issuer.rstrip("/")
 
     @property
     def client_id(self):

--- a/flaat/flask/conftest.py
+++ b/flaat/flask/conftest.py
@@ -5,11 +5,10 @@ import functools
 import copy
 
 from flaat import issuers
-from flaat.test_env import FLAAT_TRUSTED_OPS_LIST
 from pytest_cases import fixture
 
 
-@fixture(scope="session", params=["ProductionConfig"])
+@fixture(scope="session", params=["flaat.test_env"])
 def configuration(request):
     return request.param
 
@@ -19,7 +18,7 @@ def app(configuration):
     from examples.example_flask import create_app
 
     app = create_app(configuration)
-    app.config["TRUSTED_OP_LIST"] = FLAAT_TRUSTED_OPS_LIST
+    app.config["ADMIN_EMAILS"] = ["admin@foo.org", "dev@foo.org"]
     app.config["TESTING"] = True
     # other setup can go here
     yield app


### PR DESCRIPTION
This pull request fixes 2 issues:

- [x] Use `flaat.test_env` as configuration for flask example testing
- [x] Missuse of `FLAAT_ISS` as `FLAAT_ISSUER` 