### PR TITLE
No strict auth

### DIFF
--- a/flaat/__init__.py
+++ b/flaat/__init__.py
@@ -479,7 +479,14 @@ class AuthWorkflow:
             # No error, but also do nothing else
             return (args, kwargs)
 
-        user_infos = self.authenticate_user(*args, **kwargs)
+        if self.ignore_no_authn:
+            try:
+                user_infos = self.authenticate_user(*args, **kwargs)
+            except FlaatException:
+                user_infos = None
+        else:
+            user_infos = self.authenticate_user(*args, **kwargs)
+
         if user_infos is None:
             if self.ignore_no_authn:
                 # No error, but also do nothing else

--- a/flaat/flask/flask_test_cases.py
+++ b/flaat/flask/flask_test_cases.py
@@ -26,6 +26,11 @@ class Authorized:
         headers = {"Authorization": f"Bearer fake_token"}
         return path, headers
 
+    @parametrize("path", {"/info_no_strict"})
+    def case_NoBearer(self, path):
+        headers = None
+        return path, headers
+
 
 class Unauthorized:
     """Request should not pass."""
@@ -35,7 +40,7 @@ class Unauthorized:
         headers = {"Authorization": f"Bearer fake_token"}
         return path, headers
 
-    @parametrize("path", example_paths)
+    @parametrize("path", example_paths - {"/info_no_strict"})
     def case_NoBearer(self, path):
         headers = None
         return path, headers


### PR DESCRIPTION
Hello,
In these days I've been working on developing a REST API using flaat to manage authentication and authorization. For some endpoints, I would like to allow access to both authenticated and unauthenticated users, returning different infos based on the fact that the user is authenticated.

Looking at functions documentation, I saw that the decorator @inject_user_infos is what I was looking for. 

`:param strict: If set to `True`, an unauthenticated user will not be able to use the view functions and cause an error instead.`

In fact, I would like to use it with strict=False and use the UserInfos object to determine if the user has been successfully authenticated or not (just checking it is None or not). But I noticed that using the endpoint without a bearer token raised an Unauthenticated error. 

I looked at the repository issues and found that another user incurred into this behavior and specified that a bearer token is mandatory (#59). But, from the documentation, I would expect that, if strict is set to False, unauthenticated users, also ones not providing a bearer token, should be able to access the endpoint.

Since the issues was still opened, I tried to look at the cause of this behavior. I looked at the code and found that, when strict is False, self.ignore_no_authn in the _run_work_flow function of **AuthWorkFlow** class is True. But, when the self.authenticated_users function does not find a bearer token, it raises an exception before using the information to ignore non-authenticated users. So I added a try-except on that part to set user_infos = None when self.authenticate_user fails and self.ignore_no_authn is True.

I also run the tests, noticed that the test related to this behavior failed and updated it accordingly. The change involves only the test with no bearer token and using the /info_no_strict endpoint.

I hope this change could help to resolve the issue and make the code consistent with the documentation (or at least what I understood from the it).

Regards