### PR TITLE
Issuer URL recognition bug fix

### DIFF
--- a/flaat/issuers.py
+++ b/flaat/issuers.py
@@ -23,9 +23,9 @@ def is_url(string):
     """Return True if parameter is a URL, otherwise False"""
     regex = re.compile(
         r"^(?:http|ftp)s?://"  # http:// or https://
-        r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"  # domain...
+        r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)(?:\.[A-Z]{2,6}|[A-Z0-9-]{2,})*\.?|\d{1,3}\."  # domain...
         r"localhost|"  # localhost...
-        r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+        r"\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
         r"(?::\d+)?"  # optional port
         r"(?:/?|[/?]\S+)$",
         re.IGNORECASE,

--- a/flaat/tests/issuers_test.py
+++ b/flaat/tests/issuers_test.py
@@ -20,6 +20,9 @@ class TestURLs:
     def test_valid_url_https_path(self):
         assert is_url("https://heise.de/thi_s&is=difficult")
 
+    def test_short_url(self):
+        assert is_url("https://keycloak")
+
     def test_invalid_url(self):
         assert not is_url("htp://heise.de")
 


### PR DESCRIPTION
Fixed the URL definition to be able to recognize simpler URLs - the ones with only one-word names (e.g. `keycloak` instead of `keycloak.com`)

Resolves #77 